### PR TITLE
feat: update provider selection menu to highlight recommended option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -729,10 +729,11 @@ nbproject/
         let mut config = Config::load().unwrap_or_else(|_| Config::new());
 
         println!("Let's set up a provider.");
-        let provider_options = &["OpenRouter", "Simple Free OpenRouter", "Ollama", "OpenAI Compatible"];
+        let provider_options = &["Free OpenRouter (recommended)", "OpenRouter", "Ollama", "OpenAI Compatible"];
         let provider_selection = Select::new()
             .with_prompt("Select a provider")
             .items(provider_options)
+            .default(0)
             .interact()
             .map_err(|e| format!("Failed to get provider selection: {}", e))?;
 
@@ -740,12 +741,6 @@ nbproject/
 
         match provider_selection {
             0 => {
-                let mut openrouter_config = setup_openrouter_provider().await?;
-                openrouter_config.id = provider_id.clone();
-                config.providers.push(ProviderConfig::OpenRouter(openrouter_config));
-                config.active_provider = provider_id;
-            }
-            1 => {
                 let api_key: String = Input::new()
                     .with_prompt("Enter OpenRouter API key")
                     .interact_text()
@@ -780,6 +775,12 @@ nbproject/
                 };
 
                 config.providers.push(ProviderConfig::SimpleFreeOpenRouter(simple_free_config));
+                config.active_provider = provider_id;
+            }
+            1 => {
+                let mut openrouter_config = setup_openrouter_provider().await?;
+                openrouter_config.id = provider_id.clone();
+                config.providers.push(ProviderConfig::OpenRouter(openrouter_config));
                 config.active_provider = provider_id;
             }
             2 => {


### PR DESCRIPTION
## Summary

This PR updates the provider selection menu in the interactive `--add-provider` mode to better highlight the recommended option for new users.

## Changes Made

- **Updated menu text**: Changed "Simple Free OpenRouter" to "Free OpenRouter (recommended)" to make it clearer that this is the recommended option
- **Reordered menu**: Moved the recommended option to the top of the list
- **Set as default**: Made "Free OpenRouter (recommended)" the default selected option (shown with `>` symbol)
- **Maintained functionality**: All existing functionality remains unchanged, only the display has been improved

## Before
```
➜  aicommit-cli git:(master) aicommit --add-provider
Let's set up a provider.
Select a provider:
  OpenRouter
  Simple Free OpenRouter
  Ollama
  OpenAI Compatible
```

## After
```
➜  aicommit-cli git:(master) aicommit --add-provider
Let's set up a provider.
Select a provider:
> Free OpenRouter (recommended)
   OpenRouter
   Ollama
   OpenAI Compatible
```

## Technical Details

- Updated the provider options array in `setup_interactive()` function
- Swapped the match cases for indices 0 and 1 to maintain correct functionality
- Added `.default(0)` to the Select component to make the first option selected by default
- Preserved all existing configuration logic and backward compatibility

## Testing

- [x] Code compiles without errors
- [x] Menu displays correctly with new text and ordering
- [x] Default selection works as expected
- [x] All provider setup functionality remains intact

This change improves the user experience by making it immediately clear which option is recommended for new users, while maintaining full backward compatibility.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author