### PR TITLE
Add --push-all flag to push commits to all configured remotes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ A CLI tool that generates concise and descriptive git commit messages using LLMs
   - OpenAI-compatible endpoints (LM Studio, local OpenAI proxy, etc.)
 - ✅ Automatically stages changes with `--add` option
 - ✅ Pushes commits automatically with `--push`
+- ✅ Push to all remotes at once with `--push-all` (github, gitlab, etc.)
 - ✅ Interactive mode with `--dry-run`
 - ✅ Watch mode with `--watch`
 - ✅ Verbose mode with `--verbose`
@@ -482,6 +483,9 @@ aicommit --add --push
 
 # Stage all changes, pull before commit, and push after (automatically sets up upstream if needed)
 aicommit --add --pull --push
+
+# Stage all changes, commit, and push to ALL configured remotes (github, gitlab, etc.)
+aicommit --add --push-all
 ```
 
 ### Automatic Upstream Branch Setup
@@ -503,6 +507,23 @@ When using `--pull` or `--push` flags, aicommit automatically handles upstream b
   - No manual `git push --set-upstream origin <branch>` needed
 
 This makes working with new branches much easier, as you don't need to manually configure upstream tracking.
+
+### Push to All Remotes
+
+If your repository has multiple remotes (e.g. `origin` for GitHub and `gitlab` for GitLab), you can push to all of them at once using the `--push-all` flag:
+
+```bash
+# Push to all configured remotes after commit
+aicommit --push-all
+
+# Stage all changes, commit, and push to all remotes
+aicommit --add --push-all
+
+# List your configured remotes
+git remote -v
+```
+
+This is useful for mirroring your repository across multiple hosting platforms. If a push to one remote fails, aicommit will continue pushing to the remaining remotes and report the error.
 
 ## Watch Mode
 
@@ -651,9 +672,12 @@ flowchart TD
     
     Q --> R{Additional operations}
     R -->|--pull| R1[Sync with remote repository]
-    R -->|--push| R2[Push changes to remote]
+    R -->|--push| R2[Push changes to origin]
+    R -->|--push-all| R3[Get list of all remotes]
+    R3 --> R4[Push to each remote]
     R1 --> S[Done]
     R2 --> S
+    R4 --> S
     R -->|no additional options| S
     
     %% Improved watch mode with timer reset logic

--- a/src/git.rs
+++ b/src/git.rs
@@ -650,17 +650,8 @@ pub async fn run_commit(config: &Config, cli: &Cli) -> Result<(), String> {
         println!("Successfully pulled changes.");
     }
 
-    // Push changes if --push flag is set
-    if cli.push {
-        // Проверяем, имеет ли текущая ветка upstream
-        let check_upstream = Command::new("sh")
-            .arg("-c")
-            .arg("git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || echo \"\"")
-            .output()
-            .map_err(|e| format!("Failed to check upstream branch: {}", e))?;
-
-        let has_upstream = !String::from_utf8_lossy(&check_upstream.stdout).trim().is_empty();
-
+    // Push changes if --push or --push-all flag is set
+    if cli.push || cli.push_all {
         // Получаем имя текущей ветки
         let branch_output = Command::new("sh")
             .arg("-c")
@@ -670,30 +661,70 @@ pub async fn run_commit(config: &Config, cli: &Cli) -> Result<(), String> {
 
         let branch_name = String::from_utf8_lossy(&branch_output.stdout).trim().to_string();
 
-        let remote_url_info = get_remote_https_url("origin")
-            .map(|url| format!(" ({})", url))
-            .unwrap_or_default();
+        // Determine which remotes to push to
+        let remotes: Vec<String> = if cli.push_all {
+            let remotes_output = Command::new("sh")
+                .arg("-c")
+                .arg("git remote")
+                .output()
+                .map_err(|e| format!("Failed to list git remotes: {}", e))?;
 
-        let push_cmd = if has_upstream {
-            // Если upstream настроен, выполняем обычный push
-            "git push"
+            let remotes_str = String::from_utf8_lossy(&remotes_output.stdout).trim().to_string();
+            if remotes_str.is_empty() {
+                return Err("No remotes configured. Add a remote first with `git remote add`.".to_string());
+            }
+            remotes_str.lines().map(|s| s.to_string()).collect()
         } else {
-            // Если upstream не настроен, настраиваем его
-            println!("Setting upstream for branch '{}' to 'origin/{}'{}", branch_name, branch_name, remote_url_info);
-            &format!("git push --set-upstream origin {}", branch_name)
+            vec!["origin".to_string()]
         };
 
-        let push_output = Command::new("sh")
-            .arg("-c")
-            .arg(push_cmd)
-            .output()
-            .map_err(|e| format!("Failed to execute git push: {}", e))?;
+        for remote in &remotes {
+            // Проверяем, имеет ли текущая ветка upstream для данного remote
+            let check_upstream = Command::new("sh")
+                .arg("-c")
+                .arg(format!("git rev-parse --abbrev-ref --symbolic-full-name @{{upstream}} 2>/dev/null | grep -q '^{}/{}$' && echo ok || echo \"\"", remote, branch_name))
+                .output()
+                .map_err(|e| format!("Failed to check upstream branch: {}", e))?;
 
-        if !push_output.status.success() {
-            return Err(String::from_utf8_lossy(&push_output.stderr).to_string());
+            let has_upstream_for_remote = String::from_utf8_lossy(&check_upstream.stdout).trim() == "ok";
+
+            let remote_url_info = get_remote_https_url(remote)
+                .map(|url| format!(" ({})", url))
+                .unwrap_or_default();
+
+            let push_cmd = if has_upstream_for_remote || remotes.len() > 1 {
+                // For multi-remote or when upstream exists, push explicitly to the remote
+                format!("git push {} {}", remote, branch_name)
+            } else if !has_upstream_for_remote {
+                // Single remote without upstream — set it up
+                println!("Setting upstream for branch '{}' to '{}/{}'{}", branch_name, remote, branch_name, remote_url_info);
+                format!("git push --set-upstream {} {}", remote, branch_name)
+            } else {
+                "git push".to_string()
+            };
+
+            let push_output = Command::new("sh")
+                .arg("-c")
+                .arg(&push_cmd)
+                .output()
+                .map_err(|e| format!("Failed to execute git push to {}: {}", remote, e))?;
+
+            if !push_output.status.success() {
+                let stderr = String::from_utf8_lossy(&push_output.stderr).to_string();
+                eprintln!("Failed to push to {}{}: {}", remote, remote_url_info, stderr.trim());
+                if !cli.push_all {
+                    return Err(stderr);
+                }
+                // For --push-all, continue to next remote even if one fails
+                continue;
+            }
+
+            println!("Changes successfully pushed to {}/{}{}.", remote, branch_name, remote_url_info);
         }
 
-        println!("Changes successfully pushed to origin/{}{}.", branch_name, remote_url_info);
+        if cli.push_all {
+            println!("Push to all remotes completed ({} remote(s)).", remotes.len());
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,7 @@ async fn main() -> Result<(), String> {
             println!("  --dry-run             Interactive commit message generation");
             println!("  --pull                Pull changes before commit");
             println!("  --push                Automatically push changes after commit");
+            println!("  --push-all            Push changes to all configured remotes");
             println!("  --help                Display this help message");
             println!("  --version             Display version information");
             println!("  --verbose             Display verbose information");

--- a/src/types.rs
+++ b/src/types.rs
@@ -130,6 +130,10 @@ pub struct Cli {
     #[arg(long = "push")]
     pub push: bool,
 
+    /// Push changes to all configured remotes (github, gitlab, etc.)
+    #[arg(long = "push-all")]
+    pub push_all: bool,
+
     /// Display help information
     #[arg(long = "help")]
     pub help: bool,


### PR DESCRIPTION
## Summary
This PR adds support for pushing commits to all configured git remotes simultaneously, enabling users to mirror their repositories across multiple hosting platforms (e.g., GitHub, GitLab) in a single command.

## Key Changes

- **New `--push-all` CLI flag**: Added to `Cli` struct in `src/types.rs` to allow pushing to all remotes at once
- **Enhanced push logic**: Refactored `run_commit()` in `src/git.rs` to:
  - Detect and iterate through all configured remotes when `--push-all` is used
  - Check upstream tracking per-remote instead of globally
  - Push to each remote with appropriate upstream setup
  - Continue pushing to remaining remotes if one fails (instead of aborting)
  - Provide detailed feedback for each remote push operation
- **Updated documentation**: Added examples and explanation of the `--push-all` feature in `readme.md`
- **Improved error handling**: Per-remote error reporting with option to continue on failure when using `--push-all`

## Implementation Details

- When `--push-all` is used, the tool retrieves all remotes via `git remote` command
- For each remote, it checks if upstream tracking exists specifically for that remote
- Push commands are constructed to explicitly target each remote: `git push <remote> <branch>`
- If `--push-all` is set and a push fails, the error is logged but execution continues to the next remote
- If `--push` (single remote) is used and push fails, the operation aborts as before
- Added helpful user messages showing which remote is being pushed to and the final summary

## Usage Examples

```bash
# Push to all configured remotes
aicommit --push-all

# Stage, commit, and push to all remotes
aicommit --add --push-all
```

https://claude.ai/code/session_01Mo7zQ7kDbVpY7nQaQvi95w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--push-all` flag to push changes to all configured remotes simultaneously. When enabled, the tool continues pushing to remaining remotes if individual pushes fail, reporting all errors upon completion.

* **Documentation**
  * Updated documentation with usage examples and workflow diagrams demonstrating multi-remote push functionality and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->